### PR TITLE
Mobile and image improvement

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -121,8 +121,9 @@ a.view-reply:hover {
 }
 
 #game-content img {
-    height: 100%;
+    height: 300px;
     width: 100%;
+    object-fit: fill;
 }
 
 #game-content p {
@@ -161,3 +162,18 @@ a.view-reply:hover {
 .thread:last-of-type {
     margin: auto auto 0 auto;
 }*/
+
+/*responsive sizing*/
+@media (max-width: 1150px) {
+    #game-content img {
+        height: 50%;
+    }
+}
+
+
+@media (max-width: 850px) {
+    .game {
+        width: 200px;
+        height: 200px;
+    }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -258,6 +258,7 @@ footer a {
         scale: 100%;
         width: 100%;
         overflow-x: auto;
+        overflow-y: hidden;
     }
 
     #navigation-bar::-webkit-scrollbar {


### PR DESCRIPTION
Hid the submenu and search result on mobile (responsive issue needs to be resolved) and applied a height of 300px for game content image to prevent complete stretching of the images.